### PR TITLE
Fixed compilation with Stylus 0.32.1

### DIFF
--- a/stylus/responsive-utilities.styl
+++ b/stylus/responsive-utilities.styl
@@ -51,7 +51,6 @@
 
 // Print utilities
 .visible-print    { display: none !important; }
-.hidden-print     { }
 
 @media print {
   .visible-print  { display: inherit !important; }


### PR DESCRIPTION
Without removing this I got the following error. I assume its because of the empty block? 

```
ParseError: /xxx/responsive-utilities.styl:56
   52| // Print utilities
   53| .visible-print    { display: none !important; }
   54| .hidden-print     { }
   55| 
 > 56| @media print {
   57|   .visible-print  { display: inherit !important; }
   58|   .hidden-print   { display: none !important; }
   59| }

expected "indent", got "media print"

    at Parser.error (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:166:11)
    at Parser.expect (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:194:12)
    at Parser.block (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:601:12)
    at Parser.selector (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:1085:24)
    at Parser.stmt (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:550:26)
    at Parser.statement (/Users/william/projects/webshaped/node_modules/stylus/lib/parser.js:460:21)
```
