### PR TITLE
Add bower.json to allow this to be installed via bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "bootstrap-stylus",
+  "version": "2.3.2",
+  "main": "stylus/boostrap.styl",
+  "description": "A port of Twitter Bootstrap to Stylus",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "components"
+  ]
+}


### PR DESCRIPTION
Right now, https://github.com/D1plo1d/bootstrap-stylus is installed by bower. D1plo1d's fork is slightly outdated, and should be replaced with the your repo to insure that bower installs are kept in sync with the main repo... this can be done by posting a request on https://github.com/bower/bower/issues/120 after adding a `bower.json` file to this repo
