### PR TITLE
Fixed modals not dropping down enough

### DIFF
--- a/stylus/modals.styl
+++ b/stylus/modals.styl
@@ -37,8 +37,9 @@
     translate(0, -25%);
     transition-transform(0.3s ease-out);
 
-  &.in .modal-dialog
-    translate(0, 0)
+  &.in
+    .modal-dialog
+      translate(0, 0)
 
 // Shell div to position the modal with bottom padding
 .modal-dialog {


### PR DESCRIPTION
I think this is a bug in newer versions of Stylus (tested on 0.40 and 0.42). It would incorrectly compile the rule as `.modal.in.modal-dialog` instead of `.modal.in .modal-dialog`
