### PR TITLE
Remove $ from class name

### DIFF
--- a/stylus/modals.styl
+++ b/stylus/modals.styl
@@ -134,7 +134,7 @@
     box-shadow 0 5px 15px rgba(0, 0, 0, .5)
 
   // Modal sizes
-  .$modal-sm
+  .modal-sm
     width $modal-sm
 
 @media (min-width $screen-md-min)


### PR DESCRIPTION
I'm pretty sure this was a typo? But it's causing safari to be unhappy.

/cc @makebbekus
