### PR TITLE
Why is @-webkit- commented out?

### DIFF
--- a/stylus/progress-bars.styl
+++ b/stylus/progress-bars.styl
@@ -7,11 +7,11 @@
 // -------------------------
 
 // WebKit
-// @-webkit-keyframes progress-bar-stripes
-//   from
-//     background-position 40px 0
-//   to
-//     background-position 0 0
+@-webkit-keyframes progress-bar-stripes
+  from
+    background-position 40px 0
+  to
+    background-position 0 0
 
 // Spec and IE10+
 @keyframes progress-bar-stripes


### PR DESCRIPTION
Without the <code>@-webkit-</code> prefix, it does not work in Safari. Please fix it.
