### PR TITLE
Make the "vendors" variable overridable

### DIFF
--- a/stylus/mixins.styl
+++ b/stylus/mixins.styl
@@ -1,6 +1,6 @@
 // Mixins
 // --------------------------------------------------
-vendors = official
+vendors ?= official
 
 percentage($n)
   if $n == 0


### PR DESCRIPTION
This simple fix will allow developers to front-load the `vendors` variable with a different value and prevent `bootstrap-stylus` from overriding the one that was previously set.

When I updated to the latest version of `bootstrap-stylus` in one of my projects, all of my keyframe animations broke, and I traced it down to the fact that `vendors` is no longer set to the stylus default of `moz webkit o ms official`.
