### PR TITLE
better borders on tabs

### DIFF
--- a/bootstrap/navs.styl
+++ b/bootstrap/navs.styl
@@ -77,7 +77,7 @@
       margin-right 2px
       line-height $line-height-base
       border 1px solid transparent
-      border-radius $border-radius-base $border-radius-base 0 0
+      border-top-radius($border-radius-base)
 
       &:hover
         border-color $nav-tabs-link-hover-border-color $nav-tabs-link-hover-border-color $nav-tabs-border-color


### PR DESCRIPTION
I was having trouble with my tabs having border radius applied to the bottom corners. For example:
![image](https://cloud.githubusercontent.com/assets/1326248/8388475/badac776-1c1f-11e5-8e75-965518984a9a.png)

After switching to the `border-top-radius` mixin the problem was resolved.
![image](https://cloud.githubusercontent.com/assets/1326248/8388488/dca174a4-1c1f-11e5-8083-c375e2e3d1c2.png)
