### PR TITLE
fixed color calculation issue with lighten/darken build-in function in stylus

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,21 +9,18 @@ module.exports = function(grunt) {
   grunt.initConfig({
 
   stylus: {
+    options: {
+      compress: false,
+      paths: ['stylus'],
+      urlfunc: 'embedurl', // use embedurl('test.png') in our code to trigger Data URI embedding
+    },
     bootstrap: {
-      options: {
-        paths: ['stylus'],
-        urlfunc: 'embedurl', // use embedurl('test.png') in our code to trigger Data URI embedding
-      },
       files: {
         'dist/bootstrap.css': 'bootstrap/index.styl' // 1:1 compile
       }
     },
 
     theme: {
-      options: {
-        paths: ['stylus'],
-        urlfunc: 'embedurl',
-      },
       files: {
         'dist/theme.css': 'bootstrap/theme.styl' // 1:1 compile
       }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Bootstrap Stylus 3.3.5
 
 Port of the amazing [Bootstrap 3.3.5](https://github.com/twbs/bootstrap) to [Stylus 0.47.0](http://learnboost.github.com/stylus/).
 
-There might be some slight color differences due to the differences between the color functions in LESS and those in Stylus.
-
 ## Installing
 
 Latest version via [Bower](https://github.com/bower/bower):

--- a/bootstrap/forms.styl
+++ b/bootstrap/forms.styl
@@ -407,7 +407,7 @@ input[type="checkbox"]
   display block // account for any element using help-block
   margin-top 5px
   margin-bottom 10px
-  color lighten($text-color, 25%) // lighten the text some for contrast
+  color lighten($text-color, 25) // lighten the text some for contrast
 
 
 

--- a/bootstrap/jumbotron.styl
+++ b/bootstrap/jumbotron.styl
@@ -20,7 +20,7 @@
     font-weight 200
 
   > hr
-    border-top-color darken($jumbotron-bg, 10%)
+    border-top-color darken($jumbotron-bg, 10)
 
   .container &,
   .container-fluid &

--- a/bootstrap/mixins/alerts.styl
+++ b/bootstrap/mixins/alerts.styl
@@ -5,7 +5,7 @@ alert-variant($background, $border, $text-color)
   color $text-color
 
   hr
-    border-top-color darken($border, 5%)
+    border-top-color darken($border, 5)
 
   .alert-link
-    color darken($text-color, 10%)
+    color darken($text-color, 10)

--- a/bootstrap/mixins/background-variant.styl
+++ b/bootstrap/mixins/background-variant.styl
@@ -4,4 +4,4 @@ bg-variant($color)
 
   a&:hover,
   a&:focus
-    background-color darken($color, 10%)
+    background-color darken($color, 10)

--- a/bootstrap/mixins/buttons.styl
+++ b/bootstrap/mixins/buttons.styl
@@ -10,27 +10,27 @@ button-variant($color, $background, $border)
   &:focus,
   &.focus
     color $color
-    background-color darken($background, 10%)
-    border-color darken($border, 25%)
+    background-color darken($background, 10)
+    border-color darken($border, 25)
 
   &:hover
     color $color
-    background-color darken($background, 10%)
-    border-color darken($border, 12%)
+    background-color darken($background, 10)
+    border-color darken($border, 12)
 
   &:active,
   &.active,
   .open > .dropdown-toggle&
     color $color
-    background-color darken($background, 10%)
-    border-color darken($border, 12%)
+    background-color darken($background, 10)
+    border-color darken($border, 12)
 
     &:hover,
     &:focus,
     &.focus
       color $color
-      background-color darken($background, 17%)
-      border-color darken($border, 25%)
+      background-color darken($background, 17)
+      border-color darken($border, 25)
 
   &:active,
   &.active,

--- a/bootstrap/mixins/forms.styl
+++ b/bootstrap/mixins/forms.styl
@@ -23,8 +23,8 @@ form-control-validation($text-color = #555, $border-color = #ccc, $background-co
     box-shadow inset 0 1px 1px rgba(0, 0, 0, .075) // Redeclare so transitions work
 
     &:focus
-      border-color darken($border-color, 10%)
-      box-shadow inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px lighten($border-color, 20%)
+      border-color darken($border-color, 10)
+      box-shadow inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 6px lighten($border-color, 20)
 
   // Set validation states also for addons
   .input-group-addon

--- a/bootstrap/mixins/labels.styl
+++ b/bootstrap/mixins/labels.styl
@@ -5,4 +5,4 @@ label-variant($color)
   &[href]
     &:hover,
     &:focus
-      background-color darken($color, 10%)
+      background-color darken($color, 10)

--- a/bootstrap/mixins/list-group.styl
+++ b/bootstrap/mixins/list-group.styl
@@ -14,7 +14,7 @@ list-group-item-variant($state, $background, $color)
       &:hover,
       &:focus
         color $color
-        background-color darken($background, 5%)
+        background-color darken($background, 5)
 
       &.active,
       &.active:hover,

--- a/bootstrap/mixins/text-emphasis.styl
+++ b/bootstrap/mixins/text-emphasis.styl
@@ -4,4 +4,4 @@ text-emphasis-variant($color)
 
   a&:hover,
   a&:focus
-    color darken($color, 10%)
+    color darken($color, 10)

--- a/bootstrap/navbar.styl
+++ b/bootstrap/navbar.styl
@@ -496,7 +496,7 @@
 
   .navbar-collapse,
   .navbar-form
-    border-color darken($navbar-inverse-bg, 7%)
+    border-color darken($navbar-inverse-bg, 7)
 
   // Dropdowns
   .navbar-nav

--- a/bootstrap/popovers.styl
+++ b/bootstrap/popovers.styl
@@ -42,7 +42,7 @@
   padding 8px 14px
   font-size $font-size-base
   background-color $popover-title-bg
-  border-bottom 1px solid darken($popover-title-bg, 5%)
+  border-bottom 1px solid darken($popover-title-bg, 5)
   border-radius ($border-radius-large - 1) ($border-radius-large - 1) 0 0
 
 .popover-content

--- a/bootstrap/theme.styl
+++ b/bootstrap/theme.styl
@@ -41,20 +41,20 @@
 
 // Mixin for generating new styles
 btn-styles($btn-color = #555)
-  gradient-vertical($btn-color, darken($btn-color, 12%))
+  gradient-vertical($btn-color, darken($btn-color, 12))
   reset-filter() // Disable gradients for IE9 because filter bleeds through rounded corners; see https://github.com/twbs/bootstrap/issues/10620
   background-repeat repeat-x
-  border-color darken($btn-color, 14%)
+  border-color darken($btn-color, 14)
 
   &:hover,
   &:focus
-    background-color darken($btn-color, 12%)
+    background-color darken($btn-color, 12)
     background-position 0 -15px
 
   &:active,
   &.active
-    background-color darken($btn-color, 12%)
-    border-color darken($btn-color, 14%)
+    background-color darken($btn-color, 12)
+    border-color darken($btn-color, 14)
 
   &.disabled,
   &[disabled],
@@ -65,7 +65,7 @@ btn-styles($btn-color = #555)
     &.focus,
     &:active
     &.active
-      background-color darken($btn-color, 12%)
+      background-color darken($btn-color, 12)
       background-image none
 
 // Common styles
@@ -112,14 +112,14 @@ btn-styles($btn-color = #555)
 
 .dropdown-menu > li > a:hover,
 .dropdown-menu > li > a:focus
-  gradient-vertical($dropdown-link-hover-bg, darken($dropdown-link-hover-bg, 5%))
-  background-color darken($dropdown-link-hover-bg, 5%)
+  gradient-vertical($dropdown-link-hover-bg, darken($dropdown-link-hover-bg, 5))
+  background-color darken($dropdown-link-hover-bg, 5)
 
 .dropdown-menu > .active > a,
 .dropdown-menu > .active > a:hover,
 .dropdown-menu > .active > a:focus
-  gradient-vertical($dropdown-link-active-bg, darken($dropdown-link-active-bg, 5%))
-  background-color darken($dropdown-link-active-bg, 5%)
+  gradient-vertical($dropdown-link-active-bg, darken($dropdown-link-active-bg, 5))
+  background-color darken($dropdown-link-active-bg, 5)
 
 
 //
@@ -128,14 +128,14 @@ btn-styles($btn-color = #555)
 
 // Default navbar
 .navbar-default
-  gradient-vertical(lighten($navbar-default-bg, 10%), $navbar-default-bg)
+  gradient-vertical(lighten($navbar-default-bg, 10), $navbar-default-bg)
   reset-filter() // Remove gradient in IE<10 to fix bug where dropdowns don't get triggered
   border-radius $navbar-border-radius
   box-shadow inset 0 1px 0 rgba(255, 255, 255, .15), 0 1px 5px rgba(0, 0, 0, .075)
 
   .navbar-nav > .open > a,
   .navbar-nav > .active > a
-    gradient-vertical(darken($navbar-default-link-active-bg, 5%), darken($navbar-default-link-active-bg, 2%))
+    gradient-vertical(darken($navbar-default-link-active-bg, 5), darken($navbar-default-link-active-bg, 2))
     box-shadow inset 0 3px 9px rgba(0, 0, 0, .075)
 
 .navbar-brand,
@@ -144,13 +144,13 @@ btn-styles($btn-color = #555)
 
 // Inverted navbar
 .navbar-inverse
-  gradient-vertical(lighten($navbar-inverse-bg, 10%), $navbar-inverse-bg)
+  gradient-vertical(lighten($navbar-inverse-bg, 10), $navbar-inverse-bg)
   reset-filter() // Remove gradient in IE<10 to fix bug where dropdowns don't get triggered
   border-radius $navbar-border-radius
 
   .navbar-nav > .open > a,
   .navbar-nav > .active > a
-    gradient-vertical($navbar-inverse-link-active-bg, lighten($navbar-inverse-link-active-bg, 2.5%))
+    gradient-vertical($navbar-inverse-link-active-bg, lighten($navbar-inverse-link-active-bg, 2.5))
     box-shadow inset 0 3px 9px rgba(0, 0, 0, .25)
 
   .navbar-brand,
@@ -170,7 +170,7 @@ btn-styles($btn-color = #555)
     &:hover,
     &:focus
       color #fff
-      gradient-vertical($dropdown-link-active-bg, darken($dropdown-link-active-bg, 5%))
+      gradient-vertical($dropdown-link-active-bg, darken($dropdown-link-active-bg, 5))
 
 
 //
@@ -184,8 +184,8 @@ btn-styles($btn-color = #555)
 
 // Mixin for generating new styles
 alert-styles($color)
-  gradient-vertical($color, darken($color, 7.5%))
-  border-color darken($color, 15%)
+  gradient-vertical($color, darken($color, 7.5))
+  border-color darken($color, 15)
 
 // Apply the mixin to the alerts
 .alert-success
@@ -207,11 +207,11 @@ alert-styles($color)
 
 // Give the progress background some depth
 .progress
-  gradient-vertical(darken($progress-bg, 4%), $progress-bg)
+  gradient-vertical(darken($progress-bg, 4), $progress-bg)
 
 // Mixin for generating new styles
 progress-bar-styles($color)
-  gradient-vertical($color, darken($color, 10%))
+  gradient-vertical($color, darken($color, 10))
 
 // Apply the mixin to the progress bars
 .progress-bar
@@ -246,9 +246,9 @@ progress-bar-styles($color)
 .list-group-item.active,
 .list-group-item.active:hover,
 .list-group-item.active:focus
-  text-shadow 0 -1px 0 darken($list-group-active-bg, 10%)
-  gradient-vertical($list-group-active-bg, darken($list-group-active-bg, 7.5%))
-  border-color darken($list-group-active-border, 7.5%)
+  text-shadow 0 -1px 0 darken($list-group-active-bg, 10)
+  gradient-vertical($list-group-active-bg, darken($list-group-active-bg, 7.5))
+  border-color darken($list-group-active-border, 7.5)
 
   .badge
     text-shadow none
@@ -264,7 +264,7 @@ progress-bar-styles($color)
 
 // Mixin for generating new styles
 panel-heading-styles($color)
-  gradient-vertical($color, darken($color, 5%))
+  gradient-vertical($color, darken($color, 5))
 
 // Apply the mixin to the panel headings only
 .panel-default > .panel-heading
@@ -291,6 +291,6 @@ panel-heading-styles($color)
 // --------------------------------------------------
 
 .well
-  gradient-vertical(darken($well-bg, 5%), $well-bg)
-  border-color darken($well-bg, 10%)
+  gradient-vertical(darken($well-bg, 5), $well-bg)
+  border-color darken($well-bg, 10)
   box-shadow inset 0 1px 3px rgba(0, 0, 0, .05), 0 1px 0 rgba(255, 255, 255, .1)

--- a/bootstrap/variables.styl
+++ b/bootstrap/variables.styl
@@ -8,13 +8,13 @@
 //## Gray and brand colors for use across Bootstrap.
 
 $gray-base ?=           #000
-$gray-darker ?=         lighten($gray-base, 13.5%) // #222
-$gray-dark ?=           lighten($gray-base, 20%)   // #333
-$gray ?=                lighten($gray-base, 33.5%) // #555
-$gray-light ?=          lighten($gray-base, 46.7%) // #777
-$gray-lighter ?=        lighten($gray-base, 93.5%) // #eee
+$gray-darker ?=         lighten($gray-base, 13.5) // #222
+$gray-dark ?=           lighten($gray-base, 20)   // #333
+$gray ?=                lighten($gray-base, 33.5) // #555
+$gray-light ?=          lighten($gray-base, 46.7) // #777
+$gray-lighter ?=        lighten($gray-base, 93.5) // #eee
 
-$brand-primary ?=       darken(#428bca, 6.5%) // #337ab7
+$brand-primary ?=       darken(#428bca, 6.5) // #337ab7
 $brand-success ?=       #5cb85c
 $brand-info ?=          #5bc0de
 $brand-warning ?=       #f0ad4e
@@ -33,7 +33,7 @@ $text-color ?=            $gray-dark
 //** Global textual link color.
 $link-color ?=            $brand-primary
 //** Link hover color set via `darken()` function.
-$link-hover-color ?=      darken($link-color, 15%)
+$link-hover-color ?=      darken($link-color, 15)
 //** Link hover decoration.
 $link-hover-decoration ?= underline
 
@@ -150,23 +150,23 @@ $btn-default-border ?=           #ccc
 
 $btn-primary-color ?=            #fff
 $btn-primary-bg ?=               $brand-primary
-$btn-primary-border ?=           darken($btn-primary-bg, 5%)
+$btn-primary-border ?=           darken($btn-primary-bg, 5)
 
 $btn-success-color ?=            #fff
 $btn-success-bg ?=               $brand-success
-$btn-success-border ?=           darken($btn-success-bg, 5%)
+$btn-success-border ?=           darken($btn-success-bg, 5)
 
 $btn-info-color ?=               #fff
 $btn-info-bg ?=                  $brand-info
-$btn-info-border ?=              darken($btn-info-bg, 5%)
+$btn-info-border ?=              darken($btn-info-bg, 5)
 
 $btn-warning-color ?=            #fff
 $btn-warning-bg ?=               $brand-warning
-$btn-warning-border ?=           darken($btn-warning-bg, 5%)
+$btn-warning-border ?=           darken($btn-warning-bg, 5)
 
 $btn-danger-color ?=             #fff
 $btn-danger-bg ?=                $brand-danger
-$btn-danger-border ?=            darken($btn-danger-bg, 5%)
+$btn-danger-border ?=            darken($btn-danger-bg, 5)
 
 $btn-link-disabled-color ?=      $gray-light
 
@@ -243,7 +243,7 @@ $dropdown-divider-bg ?=          #e5e5e5
 //** Dropdown link text color.
 $dropdown-link-color ?=          $gray-dark
 //** Hover color for dropdown links.
-$dropdown-link-hover-color ?=    darken($gray-dark, 5%)
+$dropdown-link-hover-color ?=    darken($gray-dark, 5)
 //** Hover background for dropdown links.
 $dropdown-link-hover-bg ?=       #f5f5f5
 
@@ -366,20 +366,20 @@ $navbar-collapse-max-height ?=     340px
 
 $navbar-default-color ?=           #777
 $navbar-default-bg ?=              #f8f8f8
-$navbar-default-border ?=          darken($navbar-default-bg, 6.5%)
+$navbar-default-border ?=          darken($navbar-default-bg, 6.5)
 
 // Navbar links
 $navbar-default-link-color ?=              #777
 $navbar-default-link-hover-color ?=        #333
 $navbar-default-link-hover-bg ?=           transparent
 $navbar-default-link-active-color ?=       #555
-$navbar-default-link-active-bg ?=          darken($navbar-default-bg, 6.5%)
+$navbar-default-link-active-bg ?=          darken($navbar-default-bg, 6.5)
 $navbar-default-link-disabled-color ?=     #ccc
 $navbar-default-link-disabled-bg ?=        transparent
 
 // Navbar brand label
 $navbar-default-brand-color ?=             $navbar-default-link-color
-$navbar-default-brand-hover-color ?=       darken($navbar-default-brand-color, 10%)
+$navbar-default-brand-hover-color ?=       darken($navbar-default-brand-color, 10)
 $navbar-default-brand-hover-bg ?=          transparent
 
 // Navbar toggle
@@ -390,16 +390,16 @@ $navbar-default-toggle-border-color ?=     #ddd
 
 //=== Inverted navbar
 // Reset inverted navbar basics
-$navbar-inverse-color ?=                    lighten($gray-light, 15%)
+$navbar-inverse-color ?=                    lighten($gray-light, 15)
 $navbar-inverse-bg ?=                       #222
-$navbar-inverse-border ?=                   darken($navbar-inverse-bg, 10%)
+$navbar-inverse-border ?=                   darken($navbar-inverse-bg, 10)
 
 // Inverted navbar links
-$navbar-inverse-link-color ?=               lighten($gray-light, 15%)
+$navbar-inverse-link-color ?=               lighten($gray-light, 15)
 $navbar-inverse-link-hover-color ?=         #fff
 $navbar-inverse-link-hover-bg ?=            transparent
 $navbar-inverse-link-active-color ?=        $navbar-inverse-link-hover-color
-$navbar-inverse-link-active-bg ?=           darken($navbar-inverse-bg, 10%)
+$navbar-inverse-link-active-bg ?=           darken($navbar-inverse-bg, 10)
 $navbar-inverse-link-disabled-color ?=      #444
 $navbar-inverse-link-disabled-bg ?=         transparent
 
@@ -498,19 +498,19 @@ $jumbotron-heading-font-size ?=  ceil($font-size-base * 4.5)
 
 $state-success-text ?=           #3c763d
 $state-success-bg ?=             #dff0d8
-$state-success-border ?=         darken(spin($state-success-bg, -10), 5%)
+$state-success-border ?=         darken(spin($state-success-bg, -10), 5)
 
 $state-info-text ?=              #31708f
 $state-info-bg ?=                #d9edf7
-$state-info-border ?=            darken(spin($state-info-bg, -10), 7%)
+$state-info-border ?=            darken(spin($state-info-bg, -10), 7)
 
 $state-warning-text ?=           #8a6d3b
 $state-warning-bg ?=             #fcf8e3
-$state-warning-border ?=         darken(spin($state-warning-bg, -10), 5%)
+$state-warning-border ?=         darken(spin($state-warning-bg, -10), 5)
 
 $state-danger-text ?=            #a94442
 $state-danger-bg ?=              #f2dede
-$state-danger-border ?=          darken(spin($state-danger-bg, -10), 5%)
+$state-danger-border ?=          darken(spin($state-danger-bg, -10), 5)
 
 
 //== Tooltips
@@ -545,7 +545,7 @@ $popover-border-color ?=              rgba(0, 0, 0, .2)
 $popover-fallback-border-color ?=     #ccc
 
 //** Popover title background color
-$popover-title-bg ?=                  darken($popover-bg, 3%)
+$popover-title-bg ?=                  darken($popover-bg, 3)
 
 //** Popover arrow width
 $popover-arrow-width ?=               10px
@@ -555,9 +555,9 @@ $popover-arrow-color ?=               $popover-bg
 //** Popover outer arrow width
 $popover-arrow-outer-width ?=         ($popover-arrow-width + 1)
 //** Popover outer arrow color
-$popover-arrow-outer-color ?=         fade-in($popover-border-color, 5%)
+$popover-arrow-outer-color ?=         fade-in($popover-border-color, 5)
 //** Popover outer arrow fallback color
-$popover-arrow-outer-fallback-color ?= darken($popover-fallback-border-color, 20%)
+$popover-arrow-outer-fallback-color ?= darken($popover-fallback-border-color, 20)
 
 
 //== Labels
@@ -684,7 +684,7 @@ $list-group-active-bg ?=        $component-active-bg
 //** Border color of active list elements
 $list-group-active-border ?=    $list-group-active-bg
 //** Text color for content within active list items
-$list-group-active-text-color ?= lighten($list-group-active-bg, 40%)
+$list-group-active-text-color ?= lighten($list-group-active-bg, 40)
 
 //** Text color of disabled list items
 $list-group-disabled-color ?=      $gray-light
@@ -761,7 +761,7 @@ $thumbnail-caption-padding ?= 9px
 //##
 
 $well-bg ?=                   #f5f5f5
-$well-border ?=               darken($well-bg, 7%)
+$well-border ?=               darken($well-bg, 7)
 
 
 //== Badges


### PR DESCRIPTION
In Stylus:

```stylus
hsl(0deg, 0%, 17%)          // #2b2b2b
lighten(#2b2b2b, 10)        // #454545
hsl(0deg, 0%, 27%)          // #454545
lighten(#2b2b2b, 10%)       // #404040
hsl(0deg, 0%, 25%)          // #404040
```

In Stylus, if the input type is numeric, lighten/darken use `lightness += amount` to get the new lightness(HSL color model), else if the input type is percent, lighten/darken use `lightness += (1 - lightness) * percent` to get the new lightness.

In Less:

```less
hsl(0deg, 0%, 17%)          // #2b2b2b
lighten(#2b2b2b, 10%)       // #454545
hsl(0deg, 0%, 27%)          // $454545
```

It is just simply using `lightness += amount` to get the new lightness.

The color function is so weird in Less/SASS... So **CSS needs a hero** <_<

However~~ We could use lighten(#2b2b2b, 10) in Stylus to get the same color calculation result in LESS.