### PR TITLE
Use mixins for clearfix

### DIFF
--- a/bootstrap/button-groups.styl
+++ b/bootstrap/button-groups.styl
@@ -31,7 +31,7 @@
 // Optional Group multiple button groups together for a toolbar
 .btn-toolbar
   margin-left -5px // Offset the first child's margin
-  @extend .clearfix
+  clearfix()
 
   .btn,
   .btn-group,
@@ -143,7 +143,7 @@
 
   // Clear floats so dropdown menus can be properly placed
   > .btn-group
-    @extend .clearfix
+    clearfix()
     > .btn
       float none
 

--- a/bootstrap/index.styl
+++ b/bootstrap/index.styl
@@ -15,7 +15,6 @@
 
 // Core CSS
 @import "bootstrap/scaffolding"
-@import "bootstrap/utilities"
 @import "bootstrap/type"
 @import "bootstrap/code"
 @import "bootstrap/grid"
@@ -53,4 +52,5 @@
 @import "bootstrap/carousel"
 
 // Utility classes
+@import "bootstrap/utilities"
 @import "bootstrap/responsive-utilities"

--- a/bootstrap/mixins/grid.styl
+++ b/bootstrap/mixins/grid.styl
@@ -8,13 +8,13 @@ container-fixed($gutter = $grid-gutter-width)
   margin-left auto
   padding-left ($gutter / 2)
   padding-right ($gutter / 2)
-  @extend .clearfix
+  clearfix()
 
 // Creates a wrapper for a series of columns
 make-row($gutter = $grid-gutter-width)
   margin-left ceil($gutter / -2)
   margin-right floor($gutter / -2)
-  @extend .clearfix
+  clearfix()
 
 // Generate the extra small columns
 make-xs-column($columns, $gutter = $grid-gutter-width)

--- a/bootstrap/modals.styl
+++ b/bootstrap/modals.styl
@@ -101,7 +101,7 @@
   padding $modal-inner-padding
   text-align right // right align buttons
   border-top 1px solid $modal-footer-border-color
-  @extend .clearfix // clear it in case folks use .pull-* classes on buttons
+  clearfix() // clear it in case folks use .pull-* classes on buttons
 
   // Properly space out buttons
   .btn + .btn

--- a/bootstrap/navbar.styl
+++ b/bootstrap/navbar.styl
@@ -15,7 +15,7 @@
   border 1px solid transparent
 
   // Prevent floats from breaking the navbar
-  @extend .clearfix
+  clearfix()
 
   @media (min-width $grid-float-breakpoint)
     border-radius $navbar-border-radius
@@ -27,7 +27,7 @@
 // styling of responsive aspects.
 
 .navbar-header
-  @extend .clearfix
+  clearfix()
 
   @media (min-width $grid-float-breakpoint)
     float left
@@ -49,7 +49,7 @@
   padding-left $navbar-padding-horizontal
   border-top 1px solid transparent
   box-shadow inset 0 1px 0 rgba(255, 255, 255, .1)
-  @extend .clearfix
+  clearfix()
   -webkit-overflow-scrolling touch
 
   &.in

--- a/bootstrap/navs.styl
+++ b/bootstrap/navs.styl
@@ -10,7 +10,7 @@
   margin-bottom 0
   padding-left 0 // Override default ul/ol
   list-style none
-  @extend .clearfix
+  clearfix()
 
   > li
     position relative

--- a/bootstrap/pager.styl
+++ b/bootstrap/pager.styl
@@ -8,7 +8,7 @@
   margin $line-height-computed 0
   list-style none
   text-align center
-  @extend .clearfix
+  clearfix()
 
   li
     display inline

--- a/bootstrap/panels.styl
+++ b/bootstrap/panels.styl
@@ -14,7 +14,7 @@
 // Panel contents
 .panel-body
   padding $panel-body-padding
-  @extend .clearfix
+  clearfix()
 
 // Optional heading
 .panel-heading

--- a/bootstrap/type.styl
+++ b/bootstrap/type.styl
@@ -214,7 +214,7 @@ dd
 
 .dl-horizontal
   dd
-    @extend .clearfix // Clear the floated `dt` if an empty `dd` is present
+    clearfix() // Clear the floated `dt` if an empty `dd` is present
 
   @media (min-width $dl-horizontal-breakpoint)
     dt

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-stylus",
-  "version": "5.0.1",
+  "version": "5.0.3",
   "main": "bootstrap/index.styl",
   "description": "A port of Bootstrap 3.3.6 to Stylus",
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap",
     "stylus"
   ],
-  "version": "5.0.2",
+  "version": "5.0.3",
   "devDependencies": {
     "grunt": "~0.4.5",
     "stylus": "~0.47.0",


### PR DESCRIPTION
Go mixins ! As discussed in [issue 108](https://github.com/maxmx/bootstrap-stylus/issues/108).
This also solves the import order, utlities.styl being imported later in the index.styl, like in the official bootstrap source.